### PR TITLE
Fix/account overflow and sidebar button

### DIFF
--- a/src/features/trip/edit/Tabs/TripTabs.tsx
+++ b/src/features/trip/edit/Tabs/TripTabs.tsx
@@ -26,7 +26,7 @@ function CustomTabPanel({
       hidden={value !== index}
       id={`trip-edit-tabpanel-${index}`}
       aria-labelledby={`trip-edit-tab-${index}`}
-      style={{ height: "90vh" }}
+      style={{ minHeight: "90vh" }}
     >
       {children}
     </div>

--- a/src/features/ui/layout/AccountLayout/AccountLayout.tsx
+++ b/src/features/ui/layout/AccountLayout/AccountLayout.tsx
@@ -83,7 +83,7 @@ export default function AccountLayout() {
   }, [location.pathname]);
 
   return (
-    <Box sx={{ display: "flex" }}>
+    <Box sx={{ display: "flex", bgcolor: "grey.100", minHeight: "100vh" }}>
       {/* Desktop Drawer */}
       {md && (
         <>

--- a/src/features/ui/layout/AccountLayout/AccountLayout.tsx
+++ b/src/features/ui/layout/AccountLayout/AccountLayout.tsx
@@ -96,7 +96,7 @@ export default function AccountLayout() {
             onClick={handleDrawerToggle}
             sx={{
               borderRadius: 1,
-              position: "absolute",
+              position: "fixed",
               top: 27,
               left: `calc(${
                 isOpen ? DESKTOP_DRAWER_WIDTH : DESKTOP_MINIMIZED_DRAWER_WIDTH


### PR DESCRIPTION
- Fix overflow on trip details page
- Fixed account sidebar close/open button, to make sure it doesn't scroll together with the page